### PR TITLE
Accept str and list types for set_record data parameter too.

### DIFF
--- a/deepstreamio_client/client.py
+++ b/deepstreamio_client/client.py
@@ -88,7 +88,9 @@ class Client:
         :param path: {str} optional path
         :return: {Client} for a batch and {bool} for non-batch
         """
-        assert isinstance(data, dict), "Data has to be a dict type."
+        assert isinstance(data, dict) or \
+            isinstance(data, str) or \
+            isinstance(data, list), "Data has to be dict, list or str type."
 
         request = {
             'topic': 'record',


### PR DESCRIPTION
set_record method only accept dict. But you can set list or string or dict (json) as a record in deepstream.
Issue #2 is fixed